### PR TITLE
オーソリのタイムアウトを0にする

### DIFF
--- a/app/models/skirt/amazon_order_reference.rb
+++ b/app/models/skirt/amazon_order_reference.rb
@@ -98,7 +98,7 @@ module Skirt
     end
 
     # オーソライズ
-    def authorize(transation_timeout = nil)
+    def authorize(transation_timeout = 0)
       # オーソライズ呼び出し
       ret_xml = self.call_authorize(transation_timeout)
 
@@ -172,6 +172,10 @@ module Skirt
 
     def captured?
       %w(Completed Closed).include? self.capture_status
+    end
+
+    def authorized?
+      %w(Open).include? self.authorization_status
     end
 
   end

--- a/spec/acceptance/pay.feature
+++ b/spec/acceptance/pay.feature
@@ -9,7 +9,7 @@ Feature: Pay
     Then ボタン'確定'をクリック
   
     Then order_reference_statusが'Closed'であること
-    Then authorization_statusが'Pending'であること
+    Then authorization_statusが'Open'であること
   
   @javascript
   Scenario: ポップアップログインして購入


### PR DESCRIPTION
# 概要

オーソリが非同期モードのため、Pending状態になってしまう。

# 技術的変更点

参考：https://payments.amazon.com/documentation/apireference/201752010

オーソリを同期モードにするために、TransactionTimeout にゼロをセット。