### PR TITLE
オーソリのクローズ

### DIFF
--- a/app/models/skirt/amazon_api.rb
+++ b/app/models/skirt/amazon_api.rb
@@ -32,11 +32,8 @@ module Skirt
     end
 
     # オーソリ取り消し
-    def call_close_authorization()
-      close_reason = nil
-      client.close_authorization(
-        self.amazon_authorization_id
-      )
+    def call_close_authorization
+      client.close_authorization(self.amazon_authorization_id)
     end
 
     # キャプチャ（支払い）
@@ -64,10 +61,7 @@ module Skirt
     end
 
     def call_get_authorization_details(amazon_authorization_id)
-      resonse = client.get_authorization_details(
-        amazon_authorization_id
-      )
-
+      client.get_authorization_details(amazon_authorization_id)
     end
 
     def call_set_order_reference_details(seller_order_id = '')

--- a/app/models/skirt/amazon_api.rb
+++ b/app/models/skirt/amazon_api.rb
@@ -31,6 +31,14 @@ module Skirt
       )
     end
 
+    # オーソリ取り消し
+    def call_close_authorization()
+      close_reason = nil
+      client.close_authorization(
+        self.amazon_authorization_id
+      )
+    end
+
     # キャプチャ（支払い）
     def call_capture
       client.capture(
@@ -53,6 +61,13 @@ module Skirt
         amazon_order_reference_id,
         address_consent_token: address_consent_token
       )
+    end
+
+    def call_get_authorization_details(amazon_authorization_id)
+      resonse = client.get_authorization_details(
+        amazon_authorization_id
+      )
+
     end
 
     def call_set_order_reference_details(seller_order_id = '')

--- a/app/models/skirt/amazon_order_reference.rb
+++ b/app/models/skirt/amazon_order_reference.rb
@@ -56,14 +56,7 @@ module Skirt
     end
 
     def get_authorization_details
-p __LINE__
-p "self.amazon_authorization_id #{self.amazon_authorization_id}"
-      ret_xml = call_get_authorization_details(self.amazon_authorization_id)
-p Hash.from_xml ret_xml.body
-
-      ret_xml
-
-      # Hash.from_xml ret_xml.body
+      call_get_authorization_details(self.amazon_authorization_id)
     end
 
     def copy_details(response)
@@ -112,6 +105,7 @@ p Hash.from_xml ret_xml.body
     def authorize(transation_timeout = 0)
       # オーソライズ呼び出し
       ret_xml = self.call_authorize(transation_timeout)
+
       # 結果を保存
       self.save_authorization_result(ret_xml)
       call_close_order_reference(amazon_order_reference_id)
@@ -134,7 +128,6 @@ p Hash.from_xml ret_xml.body
              'AuthorizationDetails/AuthorizationStatus'
 
       self.authorization_status = ret_xml.get_element(path, 'State')
-
       self.authorization_status == "Closed"
     end
 
@@ -150,7 +143,6 @@ p Hash.from_xml ret_xml.body
       # You will need the Amazon Authorization Id from the
       # Authorize API response if you decide to make the
       # Capture API call separately.
-      #
       self.amazon_authorization_id = ret_xml.get_element(
         'AuthorizeResponse/AuthorizeResult/AuthorizationDetails',
         'AmazonAuthorizationId'
@@ -218,7 +210,7 @@ p Hash.from_xml ret_xml.body
     def inquire_order_status
       # ステータス取得
       ret_xml = call_get_order_reference_details(self.amazon_order_reference_id)
-p ret_xml
+
       # エラー処理
       error_code = treat_error(ret_xml, :order_reference_status_reason_code)
       raise AmazonOrderReferenceError, error_code if error_code

--- a/app/models/skirt/amazon_order_reference.rb
+++ b/app/models/skirt/amazon_order_reference.rb
@@ -118,7 +118,7 @@ module Skirt
     end
 
     # オーソライズのクローズ
-    def close_authorization()
+    def close_authorization
       self.call_close_authorization
 
       ret_xml = get_authorization_details

--- a/app/models/skirt/amazon_order_reference.rb
+++ b/app/models/skirt/amazon_order_reference.rb
@@ -112,12 +112,9 @@ p Hash.from_xml ret_xml.body
     def authorize(transation_timeout = 0)
       # オーソライズ呼び出し
       ret_xml = self.call_authorize(transation_timeout)
-p __LINE__
       # 結果を保存
       self.save_authorization_result(ret_xml)
-p __LINE__
       call_close_order_reference(amazon_order_reference_id)
-p __LINE__
 
       # エラー処理
       error_code = treat_error(ret_xml, :authorization_status_reason_code)
@@ -129,9 +126,8 @@ p __LINE__
     # オーソライズのクローズ
     def close_authorization()
       # オーソライズ呼び出し
-      ret_xml = self.call_close_authorization
+      self.call_close_authorization
 
-      # Hash.from_xml ret_xml.body
       ret_xml = get_authorization_details
 
       path = 'GetAuthorizationDetailsResponse/GetAuthorizationDetailsResult/' \
@@ -139,12 +135,8 @@ p __LINE__
 
       self.authorization_status = ret_xml.get_element(path, 'State')
 
-p __LINE__
-      p self.authorization_status
-
-      # Hash.from_xml ret_xml.body
+      self.authorization_status == "Closed"
     end
-
 
 
     # オーソライズの結果をARに保持

--- a/app/models/skirt/amazon_order_reference.rb
+++ b/app/models/skirt/amazon_order_reference.rb
@@ -119,7 +119,6 @@ module Skirt
 
     # オーソライズのクローズ
     def close_authorization()
-      # オーソライズ呼び出し
       self.call_close_authorization
 
       ret_xml = get_authorization_details
@@ -128,9 +127,10 @@ module Skirt
              'AuthorizationDetails/AuthorizationStatus'
 
       self.authorization_status = ret_xml.get_element(path, 'State')
+      self.save
+
       self.authorization_status == "Closed"
     end
-
 
     # オーソライズの結果をARに保持
     def save_authorization_result(ret_xml)

--- a/spec/acceptance/pay.feature
+++ b/spec/acceptance/pay.feature
@@ -7,16 +7,16 @@ Feature: Pay
     Given '/amazon_payments/login'にアクセスする
     Then amazonにログイン
     Then ボタン'確定'をクリック
-  
+
     Then order_reference_statusが'Closed'であること
     Then authorization_statusが'Open'であること
-  
+
   @javascript
   Scenario: ポップアップログインして購入
     Given '/amazon_payments/login?popup=true'にアクセスする
     Then amazonにポップアップログイン
     Then ボタン'確定'をクリック
-  
+
   @javascript
   Scenario: set_order_refernce_details
     Given '/amazon_payments/login'にアクセスする
@@ -24,7 +24,7 @@ Feature: Pay
     Then access_tokenを取得
     Then order_reference_idを取得
     Then set_order_refernce_detailsを正しく呼べること
-  
+
   @javascript
   Scenario: get_order_reference_details
     Given '/amazon_payments/login'にアクセスする
@@ -32,7 +32,7 @@ Feature: Pay
     Then access_tokenを取得
     Then order_reference_idを取得
     Then get_order_refernce_detailsを正しく呼べること
-  
+
   @javascript
   Scenario: confirm_order_reference
     Given '/amazon_payments/login'にアクセスする
@@ -40,7 +40,7 @@ Feature: Pay
     Then access_tokenを取得
     Then order_reference_idを取得
     Then confirm_order_refernceを正しく呼べること
-  
+
   @javascript
   Scenario: authorize
     Given '/amazon_payments/login'にアクセスする

--- a/spec/acceptance/pay.feature
+++ b/spec/acceptance/pay.feature
@@ -65,23 +65,23 @@ Feature: Pay
     Then access_tokenを取得
     Then order_reference_idを取得
   #    Then save_and_authorizeを正しく呼べること
- 
+
   @javascript
   Scenario: capture
     Given '/amazon_payments/login'にアクセスする
     Then amazonにログイン
     Then access_tokenを取得
     Then order_reference_idを取得
- 
+
     Then 0秒でauthorizeしてcaptureする
     Then capture_statusが'Completed'であること
- 
+
   @javascript
   Scenario: cancel
     Given '/amazon_payments/login'にアクセスする
     Then amazonにログイン
     Then access_tokenを取得
     Then order_reference_idを取得
- 
+
     Then cancelする
     Then order_reference_statusが'Canceled'であること

--- a/spec/acceptance/pay.feature
+++ b/spec/acceptance/pay.feature
@@ -2,77 +2,92 @@
 
 Feature: Pay
 
-  @javascript
-  Scenario: リダイレクトログインして購入
-    Given '/amazon_payments/login'にアクセスする
-    Then amazonにログイン
-    Then ボタン'確定'をクリック
+  #  @javascript
+  #  Scenario: リダイレクトログインして購入
+  #    Given '/amazon_payments/login'にアクセスする
+  #    Then amazonにログイン
+  #    Then ボタン'確定'をクリック
+  #
+  #    Then order_reference_statusが'Closed'であること
+  #    Then authorization_statusが'Open'であること
+  #  
+  #  @javascript
+  #  Scenario: ポップアップログインして購入
+  #    Given '/amazon_payments/login?popup=true'にアクセスする
+  #    Then amazonにポップアップログイン
+  #    Then ボタン'確定'をクリック
+  #
+  #  @javascript
+  #  Scenario: set_order_refernce_details
+  #    Given '/amazon_payments/login'にアクセスする
+  #    Then amazonにログイン
+  #    Then access_tokenを取得
+  #    Then order_reference_idを取得
+  #    Then set_order_refernce_detailsを正しく呼べること
+  #
+  #  @javascript
+  #  Scenario: get_order_reference_details
+  #    Given '/amazon_payments/login'にアクセスする
+  #    Then amazonにログイン
+  #    Then access_tokenを取得
+  #    Then order_reference_idを取得
+  #    Then get_order_refernce_detailsを正しく呼べること
+  #
+  #  @javascript
+  #  Scenario: confirm_order_reference
+  #    Given '/amazon_payments/login'にアクセスする
+  #    Then amazonにログイン
+  #    Then access_tokenを取得
+  #    Then order_reference_idを取得
+  #    Then confirm_order_refernceを正しく呼べること
+  #
+  #  @javascript
+  #  Scenario: authorize
+  #    Given '/amazon_payments/login'にアクセスする
+  #    Then amazonにログイン
+  #    Then access_tokenを取得
+  #    Then order_reference_idを取得
+  #    Then authorizeを正しく呼べること
 
-    Then order_reference_statusが'Closed'であること
-    Then authorization_statusが'Open'であること
-  
   @javascript
-  Scenario: ポップアップログインして購入
-    Given '/amazon_payments/login?popup=true'にアクセスする
-    Then amazonにポップアップログイン
-    Then ボタン'確定'をクリック
-
-  @javascript
-  Scenario: set_order_refernce_details
-    Given '/amazon_payments/login'にアクセスする
-    Then amazonにログイン
-    Then access_tokenを取得
-    Then order_reference_idを取得
-    Then set_order_refernce_detailsを正しく呼べること
-
-  @javascript
-  Scenario: get_order_reference_details
-    Given '/amazon_payments/login'にアクセスする
-    Then amazonにログイン
-    Then access_tokenを取得
-    Then order_reference_idを取得
-    Then get_order_refernce_detailsを正しく呼べること
-
-  @javascript
-  Scenario: confirm_order_reference
-    Given '/amazon_payments/login'にアクセスする
-    Then amazonにログイン
-    Then access_tokenを取得
-    Then order_reference_idを取得
-    Then confirm_order_refernceを正しく呼べること
-
-  @javascript
-  Scenario: authorize
+  Scenario: close_authorization
     Given '/amazon_payments/login'にアクセスする
     Then amazonにログイン
     Then access_tokenを取得
     Then order_reference_idを取得
     Then authorizeを正しく呼べること
+    # Then get_authorization_detailsする
 
-  @javascript
-  Scenario: save_and_authorize
-    Given '/amazon_payments/login'にアクセスする
-    Then amazonにログイン
-    Then access_tokenを取得
-    Then order_reference_idを取得
-  #    Then save_and_authorizeを正しく呼べること
+    Then close_authorizeを正しく呼べること
 
-  @javascript
-  Scenario: capture
-    Given '/amazon_payments/login'にアクセスする
-    Then amazonにログイン
-    Then access_tokenを取得
-    Then order_reference_idを取得
+    # Then get_authorization_detailsする
+    # Then captureする
+    # Then get_authorization_detailsする
 
-    Then 0秒でauthorizeしてcaptureする
-    Then capture_statusが'Completed'であること
-
-  @javascript
-  Scenario: cancel
-    Given '/amazon_payments/login'にアクセスする
-    Then amazonにログイン
-    Then access_tokenを取得
-    Then order_reference_idを取得
-
-    Then cancelする
-    Then order_reference_statusが'Canceled'であること
+#  @javascript
+#  Scenario: save_and_authorize
+#    Given '/amazon_payments/login'にアクセスする
+#    Then amazonにログイン
+#    Then access_tokenを取得
+#    Then order_reference_idを取得
+#  #    Then save_and_authorizeを正しく呼べること
+#
+#  @javascript
+#  Scenario: capture
+#    Given '/amazon_payments/login'にアクセスする
+#    Then amazonにログイン
+#    Then access_tokenを取得
+#    Then order_reference_idを取得
+#
+#    Then 0秒でauthorizeしてcaptureする
+#    Then capture_statusが'Completed'であること
+#
+#  @javascript
+#  Scenario: cancel
+#    Given '/amazon_payments/login'にアクセスする
+#    Then amazonにログイン
+#    Then access_tokenを取得
+#    Then order_reference_idを取得
+#
+#    Then cancelする
+#    Then order_reference_statusが'Canceled'であること

--- a/spec/acceptance/pay.feature
+++ b/spec/acceptance/pay.feature
@@ -2,52 +2,52 @@
 
 Feature: Pay
 
-  #  @javascript
-  #  Scenario: リダイレクトログインして購入
-  #    Given '/amazon_payments/login'にアクセスする
-  #    Then amazonにログイン
-  #    Then ボタン'確定'をクリック
-  #
-  #    Then order_reference_statusが'Closed'であること
-  #    Then authorization_statusが'Open'であること
-  #  
-  #  @javascript
-  #  Scenario: ポップアップログインして購入
-  #    Given '/amazon_payments/login?popup=true'にアクセスする
-  #    Then amazonにポップアップログイン
-  #    Then ボタン'確定'をクリック
-  #
-  #  @javascript
-  #  Scenario: set_order_refernce_details
-  #    Given '/amazon_payments/login'にアクセスする
-  #    Then amazonにログイン
-  #    Then access_tokenを取得
-  #    Then order_reference_idを取得
-  #    Then set_order_refernce_detailsを正しく呼べること
-  #
-  #  @javascript
-  #  Scenario: get_order_reference_details
-  #    Given '/amazon_payments/login'にアクセスする
-  #    Then amazonにログイン
-  #    Then access_tokenを取得
-  #    Then order_reference_idを取得
-  #    Then get_order_refernce_detailsを正しく呼べること
-  #
-  #  @javascript
-  #  Scenario: confirm_order_reference
-  #    Given '/amazon_payments/login'にアクセスする
-  #    Then amazonにログイン
-  #    Then access_tokenを取得
-  #    Then order_reference_idを取得
-  #    Then confirm_order_refernceを正しく呼べること
-  #
-  #  @javascript
-  #  Scenario: authorize
-  #    Given '/amazon_payments/login'にアクセスする
-  #    Then amazonにログイン
-  #    Then access_tokenを取得
-  #    Then order_reference_idを取得
-  #    Then authorizeを正しく呼べること
+  @javascript
+  Scenario: リダイレクトログインして購入
+    Given '/amazon_payments/login'にアクセスする
+    Then amazonにログイン
+    Then ボタン'確定'をクリック
+  
+    Then order_reference_statusが'Closed'であること
+    Then authorization_statusが'Open'であること
+  
+  @javascript
+  Scenario: ポップアップログインして購入
+    Given '/amazon_payments/login?popup=true'にアクセスする
+    Then amazonにポップアップログイン
+    Then ボタン'確定'をクリック
+  
+  @javascript
+  Scenario: set_order_refernce_details
+    Given '/amazon_payments/login'にアクセスする
+    Then amazonにログイン
+    Then access_tokenを取得
+    Then order_reference_idを取得
+    Then set_order_refernce_detailsを正しく呼べること
+  
+  @javascript
+  Scenario: get_order_reference_details
+    Given '/amazon_payments/login'にアクセスする
+    Then amazonにログイン
+    Then access_tokenを取得
+    Then order_reference_idを取得
+    Then get_order_refernce_detailsを正しく呼べること
+  
+  @javascript
+  Scenario: confirm_order_reference
+    Given '/amazon_payments/login'にアクセスする
+    Then amazonにログイン
+    Then access_tokenを取得
+    Then order_reference_idを取得
+    Then confirm_order_refernceを正しく呼べること
+  
+  @javascript
+  Scenario: authorize
+    Given '/amazon_payments/login'にアクセスする
+    Then amazonにログイン
+    Then access_tokenを取得
+    Then order_reference_idを取得
+    Then authorizeを正しく呼べること
 
   @javascript
   Scenario: close_authorization
@@ -56,38 +56,32 @@ Feature: Pay
     Then access_tokenを取得
     Then order_reference_idを取得
     Then authorizeを正しく呼べること
-    # Then get_authorization_detailsする
-
     Then close_authorizeを正しく呼べること
 
-    # Then get_authorization_detailsする
-    # Then captureする
-    # Then get_authorization_detailsする
-
-#  @javascript
-#  Scenario: save_and_authorize
-#    Given '/amazon_payments/login'にアクセスする
-#    Then amazonにログイン
-#    Then access_tokenを取得
-#    Then order_reference_idを取得
-#  #    Then save_and_authorizeを正しく呼べること
-#
-#  @javascript
-#  Scenario: capture
-#    Given '/amazon_payments/login'にアクセスする
-#    Then amazonにログイン
-#    Then access_tokenを取得
-#    Then order_reference_idを取得
-#
-#    Then 0秒でauthorizeしてcaptureする
-#    Then capture_statusが'Completed'であること
-#
-#  @javascript
-#  Scenario: cancel
-#    Given '/amazon_payments/login'にアクセスする
-#    Then amazonにログイン
-#    Then access_tokenを取得
-#    Then order_reference_idを取得
-#
-#    Then cancelする
-#    Then order_reference_statusが'Canceled'であること
+  @javascript
+  Scenario: save_and_authorize
+    Given '/amazon_payments/login'にアクセスする
+    Then amazonにログイン
+    Then access_tokenを取得
+    Then order_reference_idを取得
+  #    Then save_and_authorizeを正しく呼べること
+ 
+  @javascript
+  Scenario: capture
+    Given '/amazon_payments/login'にアクセスする
+    Then amazonにログイン
+    Then access_tokenを取得
+    Then order_reference_idを取得
+ 
+    Then 0秒でauthorizeしてcaptureする
+    Then capture_statusが'Completed'であること
+ 
+  @javascript
+  Scenario: cancel
+    Given '/amazon_payments/login'にアクセスする
+    Then amazonにログイン
+    Then access_tokenを取得
+    Then order_reference_idを取得
+ 
+    Then cancelする
+    Then order_reference_statusが'Canceled'であること

--- a/spec/acceptance/pay.feature
+++ b/spec/acceptance/pay.feature
@@ -56,7 +56,9 @@ Feature: Pay
     Then access_tokenを取得
     Then order_reference_idを取得
     Then authorizeを正しく呼べること
+    Then authorization_statusが'Open'なこと
     Then close_authorizeを正しく呼べること
+    Then authorization_statusが'Closed'なこと
 
   @javascript
   Scenario: save_and_authorize

--- a/spec/acceptance/steps/common_steps.rb
+++ b/spec/acceptance/steps/common_steps.rb
@@ -134,25 +134,8 @@ step "authorizeを正しく呼べること" do
 end
 
 step "close_authorizeを正しく呼べること" do
-  # @aor = Skirt::AmazonOrderReference.new
-  # @aor.amount = 10
-  # @aor.amazon_order_reference_id = @order_reference_id
-
-  # @aor.set_order_refernce_details
-  # @aor.confirm_order_reference
-
-  # @aor.inquire_order_status
-
   @aor.close_authorization
-
-  # expect(@aor.authorization_status).to eq 'Closed' 
-
-  # details = response["CloseAuthorizationResponse"]
-  # @aor.inquire_order_status
-
-
-  # response = @aor.get_authorization_details
-  # expect(details).to be_present
+  expect(@aor.authorization_status).to eq 'Closed'
 end
 
 step "captureする" do
@@ -161,13 +144,10 @@ end
 
 step "get_order_reference_detailsする" do
   response = @aor.get_order_reference_details(@aor.amazon_order_reference_id, nil)
-  p response
 end
 
 step "get_authorization_detailsする" do
-  p "get_authorization_details!!!!!!!!!!!!!"
   response = @aor.get_authorization_details
-  p response
 end
 
 step "0秒でauthorizeしてcaptureする" do

--- a/spec/acceptance/steps/common_steps.rb
+++ b/spec/acceptance/steps/common_steps.rb
@@ -133,6 +133,43 @@ step "authorizeを正しく呼べること" do
   expect(details).to be_present
 end
 
+step "close_authorizeを正しく呼べること" do
+  # @aor = Skirt::AmazonOrderReference.new
+  # @aor.amount = 10
+  # @aor.amazon_order_reference_id = @order_reference_id
+
+  # @aor.set_order_refernce_details
+  # @aor.confirm_order_reference
+
+  # @aor.inquire_order_status
+
+  @aor.close_authorization
+
+  # expect(@aor.authorization_status).to eq 'Closed' 
+
+  # details = response["CloseAuthorizationResponse"]
+  # @aor.inquire_order_status
+
+
+  # response = @aor.get_authorization_details
+  # expect(details).to be_present
+end
+
+step "captureする" do
+  response = @aor.capture
+end
+
+step "get_order_reference_detailsする" do
+  response = @aor.get_order_reference_details(@aor.amazon_order_reference_id, nil)
+  p response
+end
+
+step "get_authorization_detailsする" do
+  p "get_authorization_details!!!!!!!!!!!!!"
+  response = @aor.get_authorization_details
+  p response
+end
+
 step "0秒でauthorizeしてcaptureする" do
   @aor = Skirt::AmazonOrderReference.new
   @aor.amount = 10

--- a/spec/acceptance/steps/common_steps.rb
+++ b/spec/acceptance/steps/common_steps.rb
@@ -138,6 +138,16 @@ step "close_authorizeを正しく呼べること" do
   expect(@aor.authorization_status).to eq 'Closed'
 end
 
+step "authorization_statusが:stateなこと" do |state|
+  response = @aor.get_authorization_details
+
+  hash =  Hash.from_xml response.body
+  _state = hash["GetAuthorizationDetailsResponse"]["GetAuthorizationDetailsResult"]["AuthorizationDetails"]["AuthorizationStatus"]["State"]
+
+  expect(_state).to eq state
+end
+
+
 step "0秒でauthorizeしてcaptureする" do
   @aor = Skirt::AmazonOrderReference.new
   @aor.amount = 10

--- a/spec/acceptance/steps/common_steps.rb
+++ b/spec/acceptance/steps/common_steps.rb
@@ -138,18 +138,6 @@ step "close_authorizeを正しく呼べること" do
   expect(@aor.authorization_status).to eq 'Closed'
 end
 
-step "captureする" do
-  response = @aor.capture
-end
-
-step "get_order_reference_detailsする" do
-  response = @aor.get_order_reference_details(@aor.amazon_order_reference_id, nil)
-end
-
-step "get_authorization_detailsする" do
-  response = @aor.get_authorization_details
-end
-
 step "0秒でauthorizeしてcaptureする" do
   @aor = Skirt::AmazonOrderReference.new
   @aor.amount = 10

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -16,10 +16,12 @@ ActiveRecord::Schema.define(version: 20160816070426) do
   create_table "amazon_order_references", force: :cascade do |t|
     t.integer  "user_id"
     t.string   "amazon_order_reference_id"
+    t.string   "authorization_reference_id"
     t.string   "capture_reference_id"
     t.string   "amazon_authorization_id"
     t.string   "amount"
     t.string   "destination_state_or_region"
+    t.string   "destination_city"
     t.string   "destination_phone"
     t.string   "destination_country_code"
     t.string   "destination_postal_code"
@@ -30,12 +32,16 @@ ActiveRecord::Schema.define(version: 20160816070426) do
     t.string   "buyer_name"
     t.string   "buyer_email"
     t.string   "order_reference_status"
+    t.string   "order_reference_status_reason_code"
     t.string   "authorization_status"
+    t.string   "authorization_status_reason_code"
+    t.string   "capture_status"
+    t.string   "capture_status_reason_code"
     t.text     "authorization_result"
     t.text     "capture_result"
+    t.datetime "created_at",                         null: false
+    t.datetime "updated_at",                         null: false
     t.string   "cancel_status_reason_code"
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
   end
 
 end


### PR DESCRIPTION
# 概要

authorization を Close する（キャプチャ不可にする）ためのメソッド。

# 技術的変更点

AmazonOrderRefernce に close_authorizationメソッドを準備。

# テスト

メソッド実行前後でAuthorizationStateがOpenからCloseに変わることを確認。