### PR TITLE
キャプチャ時の金額指定

### DIFF
--- a/app/models/skirt/amazon_api.rb
+++ b/app/models/skirt/amazon_api.rb
@@ -37,11 +37,11 @@ module Skirt
     end
 
     # キャプチャ（支払い）
-    def call_capture
+    def call_capture(capture_amount = nil)
       client.capture(
         self.amazon_authorization_id,
         self.generate_capture_reference_id,
-        self.amount,
+        capture_amount || self.amount,
         currency_code: 'JPY',
         seller_capture_note: ''
       )

--- a/app/models/skirt/amazon_order_reference.rb
+++ b/app/models/skirt/amazon_order_reference.rb
@@ -187,6 +187,7 @@ module Skirt
       self.capture_result = response.to_json
       self.save
 
+      response
     end
 
     def captured?

--- a/app/models/skirt/amazon_order_reference.rb
+++ b/app/models/skirt/amazon_order_reference.rb
@@ -42,7 +42,7 @@ module Skirt
     end
 
     def get_order_reference_details(amazon_order_reference_id,
-                                    address_consent_token)
+                                    address_consent_token = nil)
 
       ret_xml = call_get_order_reference_details(
         amazon_order_reference_id,
@@ -171,8 +171,8 @@ module Skirt
       response
     end
 
-    def capture
-      ret_xml = call_capture
+    def capture(capture_amount = nil)
+      ret_xml = call_capture(capture_amount)
 
       path = 'CaptureResponse/CaptureResult' \
              '/CaptureDetails/CaptureStatus'

--- a/spec/acceptance/pay.feature
+++ b/spec/acceptance/pay.feature
@@ -75,7 +75,7 @@ Feature: Pay
     Then access_tokenを取得
     Then order_reference_idを取得
 
-    Then 0秒でauthorizeしてcaptureする
+    Then 0秒でauthorizeしてcaptureするとamountが請求されること
     Then capture_statusが'Completed'であること
 
   @javascript
@@ -85,7 +85,7 @@ Feature: Pay
     Then access_tokenを取得
     Then order_reference_idを取得
 
-    Then 0秒でauthorizeして金額指定でcaptureする
+    Then 0秒でauthorizeして金額指定でcaptureすると指定金額が請求されること
     Then capture_statusが'Completed'であること
 
   @javascript

--- a/spec/acceptance/pay.feature
+++ b/spec/acceptance/pay.feature
@@ -79,6 +79,16 @@ Feature: Pay
     Then capture_statusが'Completed'であること
 
   @javascript
+  Scenario: capture
+    Given '/amazon_payments/login'にアクセスする
+    Then amazonにログイン
+    Then access_tokenを取得
+    Then order_reference_idを取得
+
+    Then 0秒でauthorizeして金額指定でcaptureする
+    Then capture_statusが'Completed'であること
+
+  @javascript
   Scenario: cancel
     Given '/amazon_payments/login'にアクセスする
     Then amazonにログイン

--- a/spec/acceptance/steps/common_steps.rb
+++ b/spec/acceptance/steps/common_steps.rb
@@ -148,7 +148,7 @@ step "authorization_statusが:stateなこと" do |state|
 end
 
 
-step "0秒でauthorizeしてcaptureする" do
+step "0秒でauthorizeしてcaptureするとamountが請求されること" do
   @aor = Skirt::AmazonOrderReference.new
   @aor.amount = 10
   @aor.amazon_order_reference_id = @order_reference_id
@@ -158,9 +158,10 @@ step "0秒でauthorizeしてcaptureする" do
 
   response = @aor.authorize(0)
   response = @aor.capture
+  expect(response['CaptureResponse']['CaptureResult']['CaptureDetails']['CaptureAmount']['Amount']).to eq '10.00'
 end
 
-step "0秒でauthorizeして金額指定でcaptureする" do
+step "0秒でauthorizeして金額指定でcaptureすると指定金額が請求されること" do
   @aor = Skirt::AmazonOrderReference.new
   @aor.amount = 10
   @aor.amazon_order_reference_id = @order_reference_id
@@ -170,6 +171,7 @@ step "0秒でauthorizeして金額指定でcaptureする" do
 
   response = @aor.authorize(0)
   response = @aor.capture(5)
+  expect(response['CaptureResponse']['CaptureResult']['CaptureDetails']['CaptureAmount']['Amount']).to eq '5.00'
 end
 
 step "save_and_authorizeを正しく呼べること" do

--- a/spec/acceptance/steps/common_steps.rb
+++ b/spec/acceptance/steps/common_steps.rb
@@ -160,6 +160,18 @@ step "0秒でauthorizeしてcaptureする" do
   response = @aor.capture
 end
 
+step "0秒でauthorizeして金額指定でcaptureする" do
+  @aor = Skirt::AmazonOrderReference.new
+  @aor.amount = 10
+  @aor.amazon_order_reference_id = @order_reference_id
+
+  @aor.set_order_refernce_details
+  @aor.confirm_order_reference
+
+  response = @aor.authorize(0)
+  response = @aor.capture(5)
+end
+
 step "save_and_authorizeを正しく呼べること" do
   @aor = Skirt::AmazonOrderReference.new
   @aor.amount = 10


### PR DESCRIPTION
# 概要

キャプチャ時に金額を指定できるようにする。

# 技術的変更点

capture用のメソッドで引数として金額を受け取る。引数が渡されない場合は、オーソリ時のamountを使用。