### PR TITLE
for update rails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ bin/local*
 config/deploy.rb
 Capfile
 server_environments
-vendor/bundler/
+vendor/bundle/*
 .bundle
 .ruby-version
 
@@ -35,3 +35,6 @@ spec/dummy/tmp
 spec/dummy/log/*
 spec/dummy/db/test.sqlite3
 spec/support/*
+
+# JetBrains Editor
+.idea

--- a/app/controllers/skirt/amazon_order_references_controller.rb
+++ b/app/controllers/skirt/amazon_order_references_controller.rb
@@ -11,10 +11,10 @@ module Skirt
       response = @aor.get_order_reference_details(@reference_id, @access_token)
       @aor.copy_details(response)
 
-      render text: @aor.to_json
+      render plain: @aor.to_json
 
     rescue AmazonOrderReferenceError => e
-      render text: [].to_json
+      render plain: [].to_json
     end
 
   end

--- a/spec/dummy/app/controllers/amazon_payments_controller.rb
+++ b/spec/dummy/app/controllers/amazon_payments_controller.rb
@@ -29,7 +29,7 @@ class AmazonPaymentsController < ApplicationController
 
     # TODO: 完了画面へリダイレクト
 
-    render text: @aor.to_json
+    render plain: @aor.to_json
 
   end
 


### PR DESCRIPTION
# Overview
1. fix for DEPRECATION WARNING

> DEPRECATION WARNING: `render :text` is deprecated because it does not actually render a `text/plain` response. Switch to `render plain: 'plain text'` to render as `text/plain`, `render html: '<strong>HTML</strong>'` to render as `text/html`, or `render body: 'raw'` to match the deprecated behavior and render with the default Content-Type, which is `text/html`.

2. fix .gitignore for JetBrains Editor(RubyMine)